### PR TITLE
Update urban and mining rubble tiles condition on player count

### DIFF
--- a/src/components/card-setup.tsx
+++ b/src/components/card-setup.tsx
@@ -111,16 +111,18 @@ export const CardSetup = ({
                         </Box>
                     )}
 
-                    <Box>
-                        <Heading size="md">Mining Rubble Tiles</Heading>
-                        {noMinesCities.map((city, index) => (
-                            <Box key={index}>
-                                <Text pt="2" fontSize="sm">
-                                    {city}
-                                </Text>
-                            </Box>
-                        ))}
-                    </Box>
+                    {selectedPlayerCount < 4 && (
+                        <Box>
+                            <Heading size="md">Mining Rubble Tiles</Heading>
+                            {noMinesCities.map((city, index) => (
+                                <Box key={index}>
+                                    <Text pt="2" fontSize="sm">
+                                        {city}
+                                    </Text>
+                                </Box>
+                            ))}
+                        </Box>
+                    )}
 
                     {showBoatSetup && (
                         <Box>

--- a/src/components/card-setup.tsx
+++ b/src/components/card-setup.tsx
@@ -1,4 +1,12 @@
-import { Card, CardBody, Stack, StackDivider, Box, Heading, Text } from "@chakra-ui/react";
+import {
+    Card,
+    CardBody,
+    Stack,
+    StackDivider,
+    Box,
+    Heading,
+    Text,
+} from "@chakra-ui/react";
 import { Card as NucleumCard } from "../assets/expansions/card-sets.interface";
 import { useEffect, useState } from "react";
 
@@ -8,8 +16,11 @@ interface CardSetupProps {
     showBoatSetup: boolean;
 }
 
-export const CardSetup = ({ selectedPlayerCount, cards, showBoatSetup }: CardSetupProps) => {
-
+export const CardSetup = ({
+    selectedPlayerCount,
+    cards,
+    showBoatSetup,
+}: CardSetupProps) => {
     const [noBuildingsCities, setNoBuildingsCities] = useState<string[]>([]);
     const [noMinesCities, setNoMinesCities] = useState<string[]>([]);
     const [boatSpaces, setBoatSpaces] = useState<number[]>([]);
@@ -27,21 +38,20 @@ export const CardSetup = ({ selectedPlayerCount, cards, showBoatSetup }: CardSet
             selectedPlayerCount === 2
                 ? firstCardBuildings[2]
                 : [...firstCardBuildings[2], ...(firstCardBuildings[3] || [])]
-        )
+        );
         setNoMinesCities(
             selectedPlayerCount === 2
                 ? firstCardMines[2]
                 : [...firstCardMines[2], ...(firstCardMines[3] || [])]
-        )
+        );
         if (firstCardBoatSpaces) {
             setBoatSpaces(
                 selectedPlayerCount === 2
                     ? firstCardBoatSpaces[2]
                     : firstCardBoatSpaces[3]
-            )
+            );
         }
-
-    }, [selectedPlayerCount, cards])
+    }, [selectedPlayerCount, cards]);
 
     if (cards.length === 0) {
         return null;
@@ -50,62 +60,62 @@ export const CardSetup = ({ selectedPlayerCount, cards, showBoatSetup }: CardSet
     return (
         <Card>
             <CardBody>
-                <Stack divider={<StackDivider />} spacing='4'>
+                <Stack divider={<StackDivider />} spacing="4">
                     <Box>
-                        <Heading size='md'>
-                            Starting Nucleum Token
-                        </Heading>
-                        <Text pt='2' fontSize='sm'>
+                        <Heading size="md">Starting Nucleum Token</Heading>
+                        <Text pt="2" fontSize="sm">
                             {cards[0].nucleumToken}
                         </Text>
                     </Box>
 
                     <Box>
-                        <Heading size='md'>
-                            Neutral Urban Buildings
-                        </Heading>
-                        {cards.filter(
-                            card => {
-                                if (selectedPlayerCount === 2 && card.publicBuilding) {
+                        <Heading size="md">Neutral Urban Buildings</Heading>
+                        {cards
+                            .filter((card) => {
+                                if (
+                                    selectedPlayerCount === 2 &&
+                                    card.publicBuilding
+                                ) {
                                     return true;
-                                } else if (selectedPlayerCount > 2 && (card.publicBuilding3Plus || card.publicBuilding)) {
+                                } else if (
+                                    selectedPlayerCount > 2 &&
+                                    (card.publicBuilding3Plus ||
+                                        card.publicBuilding)
+                                ) {
                                     return true;
                                 }
                                 return false;
-                            }
-                        ).map(card => (
-                            <Box key={card.key}>
-                                <Text pt='2' fontSize='sm'>
-                                    {
-                                        card.publicBuilding3Plus && selectedPlayerCount >= 3
+                            })
+                            .map((card) => (
+                                <Box key={card.key}>
+                                    <Text pt="2" fontSize="sm">
+                                        {card.publicBuilding3Plus &&
+                                        selectedPlayerCount >= 3
                                             ? card.publicBuilding3Plus
-                                            : card.publicBuilding
-                                    }
-                                </Text>
-                            </Box>
-                        ))}
+                                            : card.publicBuilding}
+                                    </Text>
+                                </Box>
+                            ))}
                     </Box>
 
-                    <Box>
-                        <Heading size='md'>
-                            Urban Rubble Tiles
-                        </Heading>
-                        {noBuildingsCities.map((city, index) => (
-                            <Box key={index}>
-                                <Text pt='2' fontSize='sm'>
-                                    {city}
-                                </Text>
-                            </Box>
-                        ))}
-                    </Box>
+                    {selectedPlayerCount < 4 && (
+                        <Box>
+                            <Heading size="md">Urban Rubble Tiles</Heading>
+                            {noBuildingsCities.map((city, index) => (
+                                <Box key={index}>
+                                    <Text pt="2" fontSize="sm">
+                                        {city}
+                                    </Text>
+                                </Box>
+                            ))}
+                        </Box>
+                    )}
 
                     <Box>
-                        <Heading size='md'>
-                            Mining Rubble Tiles
-                        </Heading>
+                        <Heading size="md">Mining Rubble Tiles</Heading>
                         {noMinesCities.map((city, index) => (
                             <Box key={index}>
-                                <Text pt='2' fontSize='sm'>
+                                <Text pt="2" fontSize="sm">
                                     {city}
                                 </Text>
                             </Box>
@@ -114,12 +124,10 @@ export const CardSetup = ({ selectedPlayerCount, cards, showBoatSetup }: CardSet
 
                     {showBoatSetup && (
                         <Box>
-                            <Heading size='md'>
-                                Neutral Boat Spaces
-                            </Heading>
+                            <Heading size="md">Neutral Boat Spaces</Heading>
                             {boatSpaces.map((space, index) => (
                                 <Box key={index}>
-                                    <Text pt='2' fontSize='sm'>
+                                    <Text pt="2" fontSize="sm">
                                         {space}
                                     </Text>
                                 </Box>
@@ -127,8 +135,7 @@ export const CardSetup = ({ selectedPlayerCount, cards, showBoatSetup }: CardSet
                         </Box>
                     )}
                 </Stack>
-
             </CardBody>
         </Card>
     );
-}
+};


### PR DESCRIPTION
Excellent tools!

I update the condition for showing the urban and mining rubble tiles for reduce confusion when setup 4 players game.

As to the rules, the urban rubble tiles and mining rubble tiles are only setup when players are 3 or fewer. 

![image](https://github.com/user-attachments/assets/28d5e407-78eb-41ea-87f1-750b11c3685f)